### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/docs/Multiplexer.md
+++ b/docs/Multiplexer.md
@@ -14,7 +14,7 @@ mux.handle("/foo/bar")
 	.del(del_handler);
 ```
 
-##Order matters
+## Order matters
 
 A request is dispatched to the first matching pattern found in the order that they were defined, irrespective of all other patterns. Patterns will be considered a match if all of their components are found in the request resource, therefore the pattern "**/**" will match all requests unless registered *after* any of your more specific patterns.
 
@@ -60,13 +60,13 @@ handle("/foo").get(foo2);
 handle("/foo/bar").get(foo3);
 ```
 
-#Request Routing
+# Request Routing
 
 Served supports a range of useful syntaxes to assist in defining RESTful resource patterns. Once compiled by the Served multiplexer, a pattern can be considered an array of segments, where each segment is constructed from the pattern once split by the path separator "**/**" character.
 
 Here is a breakdown of the various segment types.
 
-###Static
+### Static
 
 This is the simplest type of segment. It is compiled from a static string, and matches only that exact string. The following pattern would compile into three static segments:
 
@@ -76,7 +76,7 @@ This is the simplest type of segment. It is compiled from a static string, and m
 
 This would only ever match a request path starting with: "**/first/second/third**"
 
-###Variable
+### Variable
 
 A variable segment is a RESTful resource parameter which can exist in any section of your pattern. It is defined between curly braces and can have an optional parameter name that will cause the variable to be parsed and captured in request.params under that name.
 
@@ -108,7 +108,7 @@ The variable name can be left blank and causes the variable segment essentially 
 /first/second/{}
 ```
 
-###Regex
+### Regex
 
 A regex segment is a RESTful resource parameter that must satisfy a regular expression before being considered a match. It is defined similarly to a variable segment between two curly braces, but also requests a colon character to separate the variable name from the regular expression.
 
@@ -141,7 +141,7 @@ but none of the following:
 
 The rules of capturing variables is the same here as for variable segments.
 
-###Empty
+### Empty
 
 An empty segment is compiled from a trailing path separator. This is a special case where the segment will match any value or no value.
 
@@ -161,7 +161,7 @@ This pattern would match any of the following request resources:
 /first/second/foo/bar/baz
 ```
 
-###Empty Regex
+### Empty Regex
 
 A regex segment where the regular expression itself is empty may be used to match complete or terminated paths (rather than path prefixes).
 

--- a/docs/Plugins.md
+++ b/docs/Plugins.md
@@ -1,4 +1,4 @@
-#Plugins
+# Plugins
 
 Served wants you to plug in. A Served plugin is a std::function of the signature:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,3 @@
-#Served - An Introduction
+# Served - An Introduction
 
 Served is a C++11 HTTP server library, designed primarily for making HTTP in C++ projects simple, fun and quick to implement. The documentation within this directory gives a useful overview of using Served, but for more detailed information about the API please refer to the header files of each component of interest.

--- a/docs/Request.md
+++ b/docs/Request.md
@@ -1,3 +1,3 @@
-#Request Object
+# Request Object
 
 Every registered handler gets access to a const request object; this is for obtaining any relevant information about the request and the client. For more information please refer to the header file at ./src/served/request.hpp.

--- a/docs/Response.md
+++ b/docs/Response.md
@@ -1,8 +1,8 @@
-#Response Object
+# Response Object
 
 Every registered handler gets access to a response object; this is used to construct your response to the client. For a detailed overview of the response object please refer to the header file at ./src/served/response.hpp.
 
-##Setting headers
+## Setting headers
 
 The header key is case-insensitive for the purposes of identifying a single header and setting a single value; however, the key itself as written here is exactly what will be sent to the client.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
