### PR TITLE
Bazel Adjustments (Imports, 0.7.0)

### DIFF
--- a/third_party/boost/BUILD
+++ b/third_party/boost/BUILD
@@ -2,7 +2,7 @@ licenses(["notice"])
 
 boost_path = "upstream"
 
-load("/third_party/boost/tool", "boost_library")
+load("//third_party/boost:tool.bzl", "boost_library")
 
 boost_library(
   name = "assert",

--- a/third_party/boost/tool.bzl
+++ b/third_party/boost/tool.bzl
@@ -1,20 +1,23 @@
-is_library = False
+def _is_library( is_library = False ):
+  if is_library:
+    include_path = "@boost/include"
+    library_path = "@boost/lib"
+    includes_pattern = include_path + "/%s/"
+    include_pattern1 = includes_pattern + "**/*.h"
+    include_pattern2 = includes_pattern + "**/*pp" # hpp and ipp
+  else:
+    includes_pattern = "upstream/%s/include"
+    include_pattern1 = includes_pattern + "/boost/**/*.h"
+    include_pattern2 = includes_pattern + "/boost/**/*pp"
 
-if is_library:
-  include_path = "@boost/include"
-  library_path = "@boost/lib"
-  includes_pattern = include_path + "/%s/"
-  include_pattern1 = includes_pattern + "**/*.h"
-  include_pattern2 = includes_pattern + "**/*pp" # hpp and ipp
-else:
-  includes_pattern = "upstream/%s/include"
-  include_pattern1 = includes_pattern + "/boost/**/*.h"
-  include_pattern2 = includes_pattern + "/boost/**/*pp"
+  return includes_pattern, include_pattern1, include_pattern2
 
 def includes_list( library_name ):
+  includes_pattern, include_pattern1, include_pattern2 = _is_library()
   return [ includes_pattern % library_name ]
 
 def hdr_list( library_name ):
+  includes_pattern, include_pattern1, include_pattern2 = _is_library()
   return native.glob([
     include_pattern1 % library_name,
     include_pattern2 % library_name,


### PR DESCRIPTION
When relying on [served](https://github.com/datasift/served) from another Bazel project, we run into issues due to the way the Boost skylark rules are imported:

```
$ bazel build //my/bazel/workspace:target
ERROR: /private/var/tmp/_bazel_lucas/413043c39fb284a3483c36335112944f/external/com_github_datasift_served/BUILD:7:1: error loading package '@com_github_datasift_served//third_party/boost': Every .bzl file must have a corresponding package, but 'third_party/boost' does not have one. Please create a BUILD file in the same or any parent directory. Note that this BUILD file does not need to do anything except exist. and referenced by '@com_github_datasift_served//:served'
[...]
ERROR: Analysis of target '//my/bazel/workspace:target' failed; build aborted
INFO: Elapsed time: 0.302s
FAILED: Build did NOT complete successfully
```

Also adjusting issues with https://github.com/datasift/served/compare/master...promiseofcake:ljk/include-boost?expand=1#diff-90a27e9b8431b4e0ed187d43a290aa13 where if/then statements cannot be used outside of a function.

```
ERROR: /Users/lucas/Workspace/repos/promiseofcake/served/third_party/boost/tool.bzl:3:1: if statements are not allowed at the top level. You may move it inside a function or use an if expression (x if condition else y). Use --incompatible_disallow_toplevel_if_statement=false to temporarily disable this check.
ERROR: error loading package 'third_party/boost': Extension 'third_party/boost/tool.bzl' has errors
```